### PR TITLE
Add message with newline, and an exception

### DIFF
--- a/src/main/java/io/jenkins/plugins/essentials/logging/EssentialsLoggingConfigurer.java
+++ b/src/main/java/io/jenkins/plugins/essentials/logging/EssentialsLoggingConfigurer.java
@@ -30,8 +30,9 @@ public class EssentialsLoggingConfigurer {
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
     public static void configure() throws Exception {
 
-        // Lower Level, debugging hack
-        LOGGER.log(Level.SEVERE, "I started!");
+        // Log to test the logging system.
+        // On purpose: the message has a newline, and an exception is attached.
+        LOGGER.log(Level.SEVERE, "Essentials plugin: \nI started!", new Exception());
 
         checkNotTooManyLogsAlready();
 


### PR DESCRIPTION
Easy way for now to check the serialization and the global behaviour.
/Maybe/ we should keep it for longer anyway to have some kind of
smoke testing log when the instance is started, like some specific
log to expect after a restart.

Anyway, for now, it's mostly for debugging and checking things do work.